### PR TITLE
Fix TypeError: bpy_struct: item.attr = val

### DIFF
--- a/mmd_tools/auto_scene_setup.py
+++ b/mmd_tools/auto_scene_setup.py
@@ -8,11 +8,11 @@ def setupFrameRanges():
         ts, te = i.frame_range
         s = min(s, ts)
         e = max(e, te)
-    bpy.context.scene.frame_start = s
-    bpy.context.scene.frame_end = e
+    bpy.context.scene.frame_start = int(s)
+    bpy.context.scene.frame_end = int(e)
     if bpy.context.scene.rigidbody_world is not None:
-        bpy.context.scene.rigidbody_world.point_cache.frame_start = s
-        bpy.context.scene.rigidbody_world.point_cache.frame_end = e
+        bpy.context.scene.rigidbody_world.point_cache.frame_start = int(s)
+        bpy.context.scene.rigidbody_world.point_cache.frame_end = int(e)
 
 def setupLighting():
     bpy.context.scene.world.light_settings.use_ambient_occlusion = True


### PR DESCRIPTION
Hello! I changed some variable types using `int()`
Because `bpy.types.Action.frame_range` is `float` type, but `frame_start` and `frame_end` in `bpy.types.Scene` are `int` type

Error log from Blender 3.0.1(Arch Linux) with mmd_tools v2.0.1:
```
Python: Traceback (most recent call last):
  File "/home/amirvincent64/.config/blender/3.0/scripts/addons/mmd_tools/operators/fileio.py", line 325, in execute
    auto_scene_setup.setupFrameRanges()
  File "/home/amirvincent64/.config/blender/3.0/scripts/addons/mmd_tools/auto_scene_setup.py", line 12, in setupFrameRanges
    bpy.context.scene.frame_end = e
TypeError: bpy_struct: item.attr = val: Scene.frame_end expected an int type, not float

location: <unknown location>:-1
```

Blender Python API:
https://docs.blender.org/api/current/bpy.types.Action.html#bpy.types.Action.frame_range
https://docs.blender.org/api/current/bpy.types.Scene.html#bpy.types.Scene.frame_start
https://docs.blender.org/api/current/bpy.types.Scene.html#bpy.types.Scene.frame_end
https://docs.blender.org/api/blender2.8/bpy.types.Action.html#bpy.types.Action.frame_range
https://docs.blender.org/api/blender2.8/bpy.types.Scene.html#bpy.types.Scene.frame_start
https://docs.blender.org/api/blender2.8/bpy.types.Scene.html#bpy.types.Scene.frame_end