### PR TITLE
add extra configuration for model selection on export and ability to …

### DIFF
--- a/mmd_tools/.idea/mmd_tools.iml
+++ b/mmd_tools/.idea/mmd_tools.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+</module>

--- a/mmd_tools/bpyutils.py
+++ b/mmd_tools/bpyutils.py
@@ -527,4 +527,3 @@ else:
         @property
         def id_objects(self):
             return self.__scene.objects
-

--- a/mmd_tools/operators/model.py
+++ b/mmd_tools/operators/model.py
@@ -3,8 +3,10 @@
 import bpy
 import mmd_tools.core.model as mmd_model
 from bpy.types import Operator
+from mmd_tools.utils import getAObject, setAObject, object_filter
 from mmd_tools.bpyutils import SceneOp, activate_layer_collection
 from mmd_tools.core.bone import FnBone
+from mmd_tools.core.model import FnModel
 
 
 class MorphSliderSetup(Operator):
@@ -213,7 +215,7 @@ class CreateMMDModelRoot(Operator):
         )
     name_e: bpy.props.StringProperty(
         name='Name(Eng)',
-        description='The english name of the MMD model',
+        description='The English name of the MMD model',
         default='New MMD Model',
         )
     scale: bpy.props.FloatProperty(
@@ -221,9 +223,121 @@ class CreateMMDModelRoot(Operator):
         description='Scale',
         default=0.08,
         )
+    sync_vertex_groups: bpy.props.BoolProperty(
+        name='Sync vertex groups',
+        description='Ensure the mesh objects have vertex groups for all bones in the armature',
+        default=True,
+        )
+    add_root_bone: bpy.props.BoolProperty(
+        name='Create root bone',
+        description='Whether to create a root bone when creating a new armature',
+        default=False,
+        )
+    add_root_bone_weights: bpy.props.BoolProperty(
+        name='Weight to root bone',
+        description='Weight the mesh objects to the root bone when creating a new armature',
+        default=False,
+        )
+    '''
+    # Some other options I tried that are probably not important enough.
+    create_armature: bpy.props.BoolProperty(
+        name='Create new armature',
+        description='Whether to create a new armature',
+        default=True,
+        )
+    target_bone_name: bpy.props.StringProperty(
+        name='Target bone name',
+        description='Optional name of the bone in the armature to weight the meshes to. * for the active bone.'
+        + '  Overridden by the root bone if one is added.',
+        default='*',
+        )
+    default_root_name_j: bpy.props.StringProperty(
+        name='Default bone name',
+        description='The Japanese name of the default bone when creating a new armature',
+        default='全ての親',
+        )
+    default_root_name_e: bpy.props.StringProperty(
+        name='Default bone name',
+        description='The English name of the default bone when creating a new armature',
+        default='Root',
+        )
+    '''
+    parenting : bpy.props.EnumProperty(
+            name='Parenting',
+            description='Which mesh objects to parent to the created armature',
+            items=(
+            ('active', "Active", "The active mesh object"),
+            ('selected', "Selected", "All selected mesh objects"),
+            ('render', "Render", "All objects visible in the render"),
+            ('visible', "Visible", "All visible mesh objects"),
+            ('none', "None", "No objects"),
+            ),
+            default='active',
+            )
 
     def execute(self, context):
-        rig = mmd_model.Model.create(self.name_j, self.name_e, self.scale, add_root_bone=True)
+        objs = context.visible_objects
+        mesh_objs = object_filter([ob for ob in objs if ob.type == "MESH"], self.parenting)
+        obj = getAObject()
+        arm = None
+        # If the active object is an armature, it makes the most sense to use it instead of any other selected armature.
+        if obj.type == "ARMATURE":
+            arm = obj
+        else:
+            # Use the first selected armature(if any) if the active object is not an armature.
+            # Otherwise, pass None to create a new armature.
+            arms = [ob for ob in context.selected_objects if ob.type == "ARMATURE"]
+            if arm is None and len(arms) > 0:
+                arm = arms[0]
+
+        # Create a new MMD model object.
+        rig = mmd_model.Model.create(self.name_j, self.name_e, self.scale, armature=arm,
+                                     add_root_bone=self.add_root_bone
+                                     )
+        arm = rig.armature()
+
+        # TODO: It might be better to have the CreateModel method accept meshes, and move this logic there
+        # If an armature has been determined, parent meshes to it according to the parenting mode.
+        if arm is not None:
+            bones = arm.data.bones
+            for ob in mesh_objs:
+                ob.parent = arm
+                vgroups = ob.vertex_groups
+                FnModel._add_armature_modifier(ob, arm)
+
+                if self.sync_vertex_groups:
+                    for b in bones:
+                        bname = b.name
+                        if vgroups.get(bname, None) is None:
+                            vgroups.new(name=bname)
+                if self.add_root_bone_weights:
+                    verts = ob.data.vertices
+                    if self.add_root_bone:
+                        root_name = "全ての親"
+                    '''
+                    # Code for options that are probably not worth including but I am leaving for review
+                    else:
+                        root_name = self.target_bone_name
+                        if root_name == "*":
+                            # We're using * to refer to the active bone.
+                            # If there are bones on the armature, try to find the active bone name.
+                            # If none exists, parent to the first bone.
+                            if len(bones):
+                                act_bone = bones.active
+                                if act_bone is None:
+                                    root_name = bones[0].name
+                            else:
+                                # If * was used but there are no bones, skip this step with a warning.
+                                print("No bones exist on the armature.\n"
+                                      + "Aborting auto-weighting for object {0}".format(str(ob.name)))
+                                continue
+                    '''
+                    vg = vgroups.get(root_name, None)
+                    if vg is None:
+                        vg = vgroups.new(name=root_name)
+                    if bones.get(root_name, None) is not None:
+                        vg.add(range(len(verts)), 1, "ADD")
+
         rig.initialDisplayFrames()
         return {'FINISHED'}
 


### PR DESCRIPTION
It seems like I did a pull request for the wrong branch a moment ago, so I'm redoing it.  Sorry if it was trouble.
Hello, I added some functions and features. The primary changed files/functions are:

    utils.py: added functions for getting the active object, setting the active object, and a function for filtering objects
    operators.model.CreateMMDModelRoot: added functionality for auto-parenting and weighting meshes on MMD Model object creation(the Create Model button)
    operators.fileio.ExportPMX: added functionality for exporting based on object properties such as selection state or active state.

They are all minor details, because I don't want to change much at first, but #3 is the most important in my opinion. I believe many people(including myself) generally only want to export the active object and not every visible object, and if many objects are visible, then manually hiding them all(and revealing again after export) can be very tedious at times. The default is currently "active" because I simply forgot to change it back to the original default of "visible".

Thanks for your time. Please let me know if you'd like me to change the implementation details.
