### PR TITLE
Blender v4

### DIFF
--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -20,7 +20,7 @@ bl_info = {
     "name": "mmd_tools",
     "author": "sugiany",
     "version": (4, 0, 0),
-    "blender": (4, 3, 0),
+    "blender": (4, 1, 0),
     "location": "View3D > Sidebar > MMD Panel",
     "description": "Utility tools for MMD model editing. (UuuNyaa's forked version)",
     "warning": "",

--- a/mmd_tools/__init__.py
+++ b/mmd_tools/__init__.py
@@ -19,7 +19,7 @@
 bl_info = {
     "name": "mmd_tools",
     "author": "sugiany",
-    "version": (4, 0, 0),
+    "version": (4, 0, 1),
     "blender": (4, 1, 0),
     "location": "View3D > Sidebar > MMD Panel",
     "description": "Utility tools for MMD model editing. (UuuNyaa's forked version)",

--- a/mmd_tools/core/pmx/exporter.py
+++ b/mmd_tools/core/pmx/exporter.py
@@ -976,27 +976,31 @@ class __PmxExporter:
     @staticmethod
     def __get_normals(mesh, matrix):
         custom_normals = None
-        if hasattr(mesh, "has_custom_normals"):
-            logging.debug(" - Calculating normals split...")
-            mesh.calc_normals_split()
-            custom_normals = [(matrix @ l.normal).normalized() for l in mesh.loops]
-            mesh.free_normals_split()
-        elif mesh.use_auto_smooth:
-            logging.debug(" - Calculating normals split (angle:%f)...", mesh.auto_smooth_angle)
-            mesh.calc_normals_split(mesh.auto_smooth_angle)
-            custom_normals = [(matrix @ l.normal).normalized() for l in mesh.loops]
-            mesh.free_normals_split()
-        else:
-            logging.debug(" - Calculating normals...")
-            mesh.calc_normals()
-            custom_normals = []
-            for f in mesh.polygons:
-                if f.use_smooth:
-                    for v in f.vertices:
-                        custom_normals.append((matrix @ mesh.vertices[v].normal).normalized())
-                else:
-                    for v in f.vertices:
-                        custom_normals.append((matrix @ f.normal).normalized())
+        if bpy.app.version < (4, 1, 0): # AutoSmooth, calc_normals_split() and correspondings had been removed from Blender 4.1
+            if hasattr(mesh, "has_custom_normals"):
+                logging.debug(" - Calculating normals split...")
+                mesh.calc_normals_split()
+                custom_normals = [(matrix @ l.normal).normalized() for l in mesh.loops]
+                mesh.free_normals_split()
+            elif mesh.use_auto_smooth:
+                logging.debug(" - Calculating normals split (angle:%f)...", mesh.auto_smooth_angle)
+                mesh.calc_normals_split(mesh.auto_smooth_angle)
+                custom_normals = [(matrix @ l.normal).normalized() for l in mesh.loops]
+                mesh.free_normals_split()
+            else:
+                logging.debug(" - Calculating normals...")
+                mesh.calc_normals()
+                custom_normals = []
+                for f in mesh.polygons:
+                    if f.use_smooth:
+                        for v in f.vertices:
+                            custom_normals.append((matrix @ mesh.vertices[v].normal).normalized())
+                    else:
+                        for v in f.vertices:
+                            custom_normals.append((matrix @ f.normal).normalized())
+        else: # Blender 4.1 or later
+            custom_normals = [(matrix @ cn.vector).normalized() for cn in mesh.corner_normals]
+
         logging.debug("   - Done (polygons:%d)", len(mesh.polygons))
         return custom_normals
 

--- a/mmd_tools/core/pmx/importer.py
+++ b/mmd_tools/core/pmx/importer.py
@@ -795,7 +795,10 @@ class PMXImporter:
         else:
             custom_normals = [(Vector(v.normal).xzy).normalized() for v in self.__model.vertices]
             mesh.normals_split_custom_set_from_vertices(custom_normals)
-        mesh.use_auto_smooth = True
+        if bpy.app.version < (4, 1, 0):
+            mesh.use_auto_smooth = True
+        else:
+            pass # It seems that we don't need to handle this anymore.
         logging.info("   - Done!!")
 
     def __renameLRBones(self, use_underscore):


### PR DESCRIPTION
To adapt Blender 4.1's Mesh.use_auto_smooth and corresponding feature removals and changes,
and Pose.bone_groups -> Armature.collections changes, 
a little fixtures added to the code. It now properly exports PMX model. 
(I only fixed codes for PMX, therefore PMD codes still remain as is)

Additionally, fixed PMX Importer to properly works on Blendere 4.1. (Just skip use_auto_smooth=True)