### PR TITLE
Avoid Bone ID conflict during merging models. (main branch)

### DIFF
--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -261,7 +261,21 @@ class FnModel:
                     continue
                 mmd_bone.additional_transform_bone_id = new_bone_id
         
-        # Change the Bone ID if necessary to make sure that each ID is still unique after joining models.
+        # Change Bone ID temporarily to large numbers to completely avoid Bone ID conflict.
+        tmp_bone_id = 1000000000
+        for child_root_object in child_root_objects:
+            child_armature_object = FnModel.find_armature(child_root_object)
+            child_pose_bones = child_armature_object.pose.bones
+            child_bone_morphs = child_root_object.mmd_root.bone_morphs
+
+            for pose_bone in child_pose_bones:
+                if pose_bone.is_mmd_shadow_bone:
+                    continue
+                if pose_bone.mmd_bone.bone_id != -1:
+                    tmp_bone_id += 1
+                    _change_bone_id(pose_bone, tmp_bone_id, child_bone_morphs, child_pose_bones)
+        
+        # Reorder child Bone IDs.
         max_bone_id = max((b.mmd_bone.bone_id for b in parent_armature_object.pose.bones if not b.is_mmd_shadow_bone), default=-1)
         
         child_root_object: bpy.types.Object

--- a/mmd_tools/core/model.py
+++ b/mmd_tools/core/model.py
@@ -261,7 +261,7 @@ class FnModel:
                     continue
                 mmd_bone.additional_transform_bone_id = new_bone_id
         
-        # Change Bone ID temporarily to large numbers to completely avoid Bone ID conflict.
+        # Change Child Bone IDs temporarily to large numbers to completely avoid Bone ID conflict.
         tmp_bone_id = 1000000000
         for child_root_object in child_root_objects:
             child_armature_object = FnModel.find_armature(child_root_object)
@@ -275,7 +275,7 @@ class FnModel:
                     tmp_bone_id += 1
                     _change_bone_id(pose_bone, tmp_bone_id, child_bone_morphs, child_pose_bones)
         
-        # Reorder child Bone IDs.
+        # Reorder Child Bone IDs.
         max_bone_id = max((b.mmd_bone.bone_id for b in parent_armature_object.pose.bones if not b.is_mmd_shadow_bone), default=-1)
         
         child_root_object: bpy.types.Object


### PR DESCRIPTION
Since Bone ID can still conflict during merging models, so I fixed it again.